### PR TITLE
Add missing callback handlers

### DIFF
--- a/src/handlers/estadisticasdb.js
+++ b/src/handlers/estadisticasdb.js
@@ -1,0 +1,15 @@
+const texts = require('../texts/es.js');
+const buttons = require('../texts/button/es.js');
+
+module.exports = (bot, query) => {
+  bot.answerCallbackQuery(query.id);
+  bot.editMessageText(
+    texts.estadisticasdb_text(),
+    {
+      chat_id: query.message.chat.id,
+      message_id: query.message.message_id,
+      parse_mode: 'HTML',
+      ...buttons.return_bt(),
+    }
+  );
+};

--- a/src/handlers/gateways.js
+++ b/src/handlers/gateways.js
@@ -1,0 +1,15 @@
+const texts = require('../texts/es.js');
+const buttons = require('../texts/button/es.js');
+
+module.exports = (bot, query) => {
+  bot.answerCallbackQuery(query.id);
+  bot.editMessageText(
+    texts.gateways_text(),
+    {
+      chat_id: query.message.chat.id,
+      message_id: query.message.message_id,
+      parse_mode: 'HTML',
+      ...buttons.return_bt(),
+    }
+  );
+};

--- a/src/handlers/idioma.js
+++ b/src/handlers/idioma.js
@@ -1,0 +1,15 @@
+const texts = require('../texts/es.js');
+const buttons = require('../texts/button/es.js');
+
+module.exports = (bot, query) => {
+  bot.answerCallbackQuery(query.id);
+  bot.editMessageText(
+    texts.idioma_text(),
+    {
+      chat_id: query.message.chat.id,
+      message_id: query.message.message_id,
+      parse_mode: 'HTML',
+      ...buttons.return_bt(),
+    }
+  );
+};

--- a/src/handlers/informacion.js
+++ b/src/handlers/informacion.js
@@ -1,0 +1,15 @@
+const texts = require('../texts/es.js');
+const buttons = require('../texts/button/es.js');
+
+module.exports = (bot, query, config) => {
+  bot.answerCallbackQuery(query.id);
+  bot.editMessageText(
+    texts.info(config),
+    {
+      chat_id: query.message.chat.id,
+      message_id: query.message.message_id,
+      parse_mode: 'HTML',
+      ...buttons.return_bt(),
+    }
+  );
+};

--- a/src/handlers/next.js
+++ b/src/handlers/next.js
@@ -1,0 +1,15 @@
+const texts = require('../texts/es.js');
+const buttons = require('../texts/button/es.js');
+
+module.exports = (bot, query, config) => {
+  bot.answerCallbackQuery(query.id);
+  bot.editMessageText(
+    texts.tools_2(config),
+    {
+      chat_id: query.message.chat.id,
+      message_id: query.message.message_id,
+      parse_mode: 'HTML',
+      ...buttons.tools_bt(),
+    }
+  );
+};

--- a/src/handlers/recompensas.js
+++ b/src/handlers/recompensas.js
@@ -1,0 +1,15 @@
+const texts = require('../texts/es.js');
+const buttons = require('../texts/button/es.js');
+
+module.exports = (bot, query) => {
+  bot.answerCallbackQuery(query.id);
+  bot.editMessageText(
+    texts.recompensas_text(),
+    {
+      chat_id: query.message.chat.id,
+      message_id: query.message.message_id,
+      parse_mode: 'HTML',
+      ...buttons.return_bt(),
+    }
+  );
+};

--- a/src/handlers/sitiosdb.js
+++ b/src/handlers/sitiosdb.js
@@ -1,0 +1,15 @@
+const texts = require('../texts/es.js');
+const buttons = require('../texts/button/es.js');
+
+module.exports = (bot, query) => {
+  bot.answerCallbackQuery(query.id);
+  bot.editMessageText(
+    texts.sitiosdb_text(),
+    {
+      chat_id: query.message.chat.id,
+      message_id: query.message.message_id,
+      parse_mode: 'HTML',
+      ...buttons.return_bt(),
+    }
+  );
+};

--- a/src/handlers/xcommerce.js
+++ b/src/handlers/xcommerce.js
@@ -1,0 +1,15 @@
+const texts = require('../texts/es.js');
+const buttons = require('../texts/button/es.js');
+
+module.exports = (bot, query) => {
+  bot.answerCallbackQuery(query.id);
+  bot.editMessageText(
+    texts.xcommerce_text(),
+    {
+      chat_id: query.message.chat.id,
+      message_id: query.message.message_id,
+      parse_mode: 'HTML',
+      ...buttons.return_bt(),
+    }
+  );
+};

--- a/src/texts/es.js
+++ b/src/texts/es.js
@@ -81,7 +81,6 @@ Próximamente nuevas herramientas.
   estadisticasdb_text: () => `Estadísticas generales de la base de datos`,
 
   recompensas_text: () => `Sistema de recompensas pendiente`,
-
   all_buttons: () => ({
     start: buttons.start(),
     tools_bt: buttons.tools_bt(),

--- a/src/texts/es.js
+++ b/src/texts/es.js
@@ -1,14 +1,15 @@
 const moment = require('moment-timezone');
+const buttons = require('./button/es.js');
 
 module.exports = {
   start: (config, msg) => {
-  const fechaMadrid = moment().tz('Europe/Madrid').format('YYYY-MM-DD hh:mm:ss A [Madrid, España.]');
-  const username = msg.from.username ? `@${msg.from.username}` : msg.from.first_name;
+    const fechaMadrid = moment().tz('Europe/Madrid').format('YYYY-MM-DD hh:mm:ss A [Madrid, España.]');
+    const username = msg.from.username ? `@${msg.from.username}` : msg.from.first_name;
 
-  return `
+    return `
 Bienvenido ${config.botName} Bot  |  <code>${fechaMadrid}</code>
 
-[🇪🇸] Hola ${username} Bienvenido a ${config.botName} Telegram Bot, las puertas de enlace, las herramientas y las funciones se agregan constantemente, para saber que mis diferentes comandos usan los botones que se muestran aquí: 
+[🇪🇸] Hola ${username} Bienvenido a ${config.botName} Telegram Bot, las puertas de enlace, las herramientas y las funciones se agregan constantemente, para saber que mis diferentes comandos usan los botones que se muestran aquí:
 ━━━━━━━━━━━━━
 <code>Api Bot El estado es: Online ✅ | ${config.botName} Api ¡Está en línea!!</code>
 `;
@@ -44,19 +45,47 @@ Chequeo de IP Fraudulenta:
 Formato: <code>$ip 1.1.1.1</code>
 Estado: <code>¡En línea! ✅</code>
 ━━━━━━━━━━━━
+  `,
+
+  tools_2: (config) => `
+Eonx Chk Herramientas / Página 2
+━━━━━━━━━━━━
+Próximamente nuevas herramientas.
+━━━━━━━━━━━━
 `,
 
-return_message: () => `Puedes volver a abrir el menú en 10 segundos`,
+  return_message: () => `Puedes volver a abrir el menú en 10 segundos`,
 
-delete_msg: () => `Podrás volver a usar el menú usando /start`,
+  delete_msg: () => `Podrás volver a usar el menú usando /start`,
 
   hola: () => `hola xd`,
 
-xcloud_text: (config, user) => `
->_ $Comenzar_ ${config.botName} Welcome @${user.username || user.first_name}  - Cloud DB 
+  xcloud_text: (config, user) => `
+>_ $Comenzar_ ${config.botName} Welcome @${user.username || user.first_name}  - Cloud DB
 
-[🇪🇸] Bienvenido a la nueva suscripción de ${config.botName} Cloud, sus datos compartidos en la nube con ${config.botName} se almacenarán aquí, navegue a través de los botones para descubrir qué es lo nuevo que tenemos para usted:       
+[🇪🇸] Bienvenido a la nueva suscripción de ${config.botName} Cloud, sus datos compartidos en la nube con ${config.botName} se almacenarán aquí, navegue a través de los botones para descubrir qué es lo nuevo que tenemos para usted:
 
 <code>${config.botName} Cloud Version:  0.0.1</code>  | ${config.botName} Cloud Plan:  <code>Premium Cloud</code>
 `,
-}
+
+  gateways_text: () => `Lista de gateways próximamente`,
+
+  informacion_text: (config) => module.exports.info(config),
+
+  xcommerce_text: () => `xCommerce en construcción`,
+
+  idioma_text: () => `Función de idioma disponible pronto`,
+
+  sitiosdb_text: () => `Listado de sitios de la base de datos`,
+
+  estadisticasdb_text: () => `Estadísticas generales de la base de datos`,
+
+  recompensas_text: () => `Sistema de recompensas pendiente`,
+
+  all_buttons: () => ({
+    start: buttons.start(),
+    tools_bt: buttons.tools_bt(),
+    return_bt: buttons.return_bt(),
+    xcloud_bt: buttons.xcloud_bt(),
+  }),
+};

--- a/src/texts/es.js
+++ b/src/texts/es.js
@@ -1,10 +1,14 @@
-const moment = require('moment-timezone');
-const buttons = require('./button/es.js');
+const moment = require("moment-timezone");
+const buttons = require("./button/es.js");
 
 module.exports = {
   start: (config, msg) => {
-    const fechaMadrid = moment().tz('Europe/Madrid').format('YYYY-MM-DD hh:mm:ss A [Madrid, España.]');
-    const username = msg.from.username ? `@${msg.from.username}` : msg.from.first_name;
+    const fechaMadrid = moment()
+      .tz("Europe/Madrid")
+      .format("YYYY-MM-DD hh:mm:ss A [Madrid, España.]");
+    const username = msg.from.username
+      ? `@${msg.from.username}`
+      : msg.from.first_name;
 
     return `
 Bienvenido ${config.botName} Bot  |  <code>${fechaMadrid}</code>


### PR DESCRIPTION
## Summary
- implement handlers for all buttons defined in `texts/button/es.js`
- add helper texts for new callbacks

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: polling_error due to Telegram token)*

------
https://chatgpt.com/codex/tasks/task_e_684718b02c688330b2e9475792652cb3